### PR TITLE
fix: Move directory validation into Click.Path argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ### Fix
 
+- Move `--output-dir` validation to use Click's in-built checks to notify the user earlier.
 - Update authors so that we appear as the contact on PyPi instead of Bede.
 - PyPi URL now points to new Pathogena project.
 - Default pipeline entry incorrectly set to `mycobacterium` instead of `mycobacteria` during refactor.
+
+### Chore 
+
+- Update `--out-dir` to `--output-dir` in the `download` sub-command to be consistent with other commands.
 
 ## 2.0.0rc1 (2024-07-18)
 

--- a/src/pathogena/cli.py
+++ b/src/pathogena/cli.py
@@ -60,9 +60,11 @@ def autocomplete() -> None:
 )
 @click.option(
     "--output-dir",
-    type=click.Path(exists=True, dir_okay=True, readable=True, path_type=Path),
-    default=Path("."),
-    help="Output directory for cleaned FASTQ files, lib.DEFAULT_METADATA to the current working directory.",
+    type=click.Path(
+        file_okay=False, dir_okay=True, writable=True, exists=True, path_type=Path
+    ),
+    default=".",
+    help="Output directory for the cleaned FastQ files, defaults to the current working directory.",
 )
 @click.option(
     "--threads",
@@ -85,7 +87,6 @@ def decontaminate(
     """
     batch = models.create_batch_from_csv(input_csv, skip_fastq_check)
     batch.validate_all_sample_fastqs()
-    util.check_outdir(output_dir)
     cleaned_batch_metadata = lib.decontaminate_samples_with_hostile(
         input_csv, batch, threads, output_dir
     )
@@ -124,9 +125,11 @@ def decontaminate(
 )
 @click.option(
     "--output-dir",
-    type=click.Path(exists=True, dir_okay=True, readable=True, path_type=Path),
-    default=Path("."),
-    help="Output directory for cleaned FASTQ files, lib.DEFAULT_METADATA to the current working directory.",
+    type=click.Path(
+        file_okay=False, dir_okay=True, writable=True, exists=True, path_type=Path
+    ),
+    default=".",
+    help="Output directory for the cleaned FastQ files, defaults to the current working directory.",
 )
 def upload(
     upload_csv: Path,
@@ -156,7 +159,6 @@ def upload(
         batch.validate_all_sample_fastqs()
         batch.update_sample_metadata()
     else:
-        util.check_outdir(output_dir)
         cleaned_batch_metadata = lib.decontaminate_samples_with_hostile(
             upload_csv, batch, threads, output_dir=output_dir
         )
@@ -176,7 +178,12 @@ def upload(
     "--inputs", is_flag=True, help="Also download decontaminated input FASTQ file(s)"
 )
 @click.option(
-    "--out-dir", type=click.Path(file_okay=False), default=".", help="Output directory"
+    "--output-dir",
+    type=click.Path(
+        file_okay=False, dir_okay=True, writable=True, exists=True, path_type=Path
+    ),
+    default=".",
+    help="Output directory for the downloaded files.",
 )
 @click.option(
     "--rename/--no-rename",
@@ -189,7 +196,7 @@ def download(
     *,
     filenames: str = "main_report.json",
     inputs: bool = False,
-    out_dir: Path = Path(),
+    output_dir: Path = Path(),
     rename: bool = True,
     host: str | None = None,
 ) -> None:
@@ -203,7 +210,7 @@ def download(
             samples=samples,
             filenames=filenames,
             inputs=inputs,
-            out_dir=out_dir,
+            out_dir=output_dir,
             host=host,
         )
     elif Path(samples).is_file():
@@ -211,7 +218,7 @@ def download(
             mapping_csv=samples,
             filenames=filenames,
             inputs=inputs,
-            out_dir=out_dir,
+            out_dir=output_dir,
             rename=rename,
             host=host,
         )

--- a/src/pathogena/lib.py
+++ b/src/pathogena/lib.py
@@ -23,7 +23,7 @@ import hostile
 
 from pathogena import util, models
 from pathogena.models import UploadBatch, UploadSample
-from pathogena.util import DOMAINS, MissingError, check_outdir
+from pathogena.util import DOMAINS, MissingError
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
@@ -620,7 +620,6 @@ def download_single(
     out_dir: Path,
 ):
     logging.info(f"Downloading {filename}")
-    check_outdir(out_dir)
     with client.stream("GET", url=url, headers=headers) as r:
         file_size = int(r.headers.get("content-length", 0))
         progress = tqdm(

--- a/src/pathogena/util.py
+++ b/src/pathogena/util.py
@@ -268,22 +268,6 @@ def command_exists(command: str) -> bool:
     return result.returncode == 0
 
 
-def check_outdir(path: Path) -> None:
-    """Given an outdir path, check that it exists (and is a directory).
-
-    Args:
-        path (Path): Outdir path
-    """
-    if path.exists():
-        if path.is_dir():
-            return
-        logging.error(f"Given out dir ({str(path)}) exists, but is a file!")
-        raise InvalidPathError(f"Given out dir ({str(path)}) exists, but is a file!")
-
-    logging.error(f"Given out dir ({str(path)}) does not exist!")
-    raise InvalidPathError(f"Given out dir ({str(path)}) does not exist!")
-
-
 def gzip_file(input_file: Path, output_file: str) -> Path:
     logging.info(
         f"Gzipping file: {input_file.name} prior to upload. This may take a while depending on the size of the file."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,41 @@ def test_cli_decontaminate_illumina(illumina_sample_csv):
     [os.remove(f) for f in os.listdir(".") if f.endswith(".fastq.gz")]
 
 
+def test_cli_decontaminate_illumina_with_output_dir(illumina_sample_csv):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["decontaminate", str(illumina_sample_csv), "--output-dir", "."]
+    )
+    assert result.exit_code == 0
+    [os.remove(f) for f in os.listdir(".") if f.endswith(".fastq.gz")]
+
+
+def test_cli_fail_decontaminate_output_dir(illumina_sample_csv):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["decontaminate", str(illumina_sample_csv), "--output-dir", "totallyfakedir"],
+    )
+    assert result.exit_code != 0
+    assert "Directory 'totallyfakedir' does not exist" in result.stdout
+
+
+def test_cli_fail_upload_output_dir(illumina_sample_csv):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["upload", str(illumina_sample_csv), "--output-dir", "totallyfakedir"]
+    )
+    assert result.exit_code != 0
+    assert "Directory 'totallyfakedir' does not exist" in result.stdout
+
+
+def test_cli_fail_download_output_dir(illumina_sample_csv):
+    runner = CliRunner()
+    result = runner.invoke(main, ["download", "--output-dir", "totallyfakedir"])
+    assert result.exit_code != 0
+    assert "Directory 'totallyfakedir' does not exist" in result.stdout
+
+
 def test_validation_fail_control(invalid_control_csv):
     runner = CliRunner()
     result = runner.invoke(main, ["validate", str(invalid_control_csv)])


### PR DESCRIPTION
[Related ticket](https://pathogena.atlassian.net/browse/PAPD-38)

Use Click's built in validation for Path-like arguments so that the user is warned as early as possible for issues.