### PR TITLE
remove json dumps from telemetry data

### DIFF
--- a/src/pathogena/lib.py
+++ b/src/pathogena/lib.py
@@ -209,7 +209,7 @@ def create_batch_on_server(
         "country": country,
         "name": batch_name,
         "amplicon_scheme": amplicon_scheme,
-        "telemetry_data": json.dumps(telemetry_data),
+        "telemetry_data": telemetry_data,
     }
 
     url = f"{get_protocol()}://{host}/api/v1/batches"


### PR DESCRIPTION
Previously, telemetry data was being sent to api/v1/batches as a string according to swagger documentation. However, this causes escape characters to be included in the database field, hindering pulling require data out of the field. This is solved by sending the telemetry data as json.

