### PR TITLE
EV-1787: make client compliant with upload API modelling changes for logical samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- [EV-1787](https://eit-oxford.atlassian.net/browse/EV-1787): Update client to make compliant with upload API sample modelling
+
 ## 2.1.0 (2025-01-22)
 
 ### Added

--- a/docs/install-dev.md
+++ b/docs/install-dev.md
@@ -58,7 +58,7 @@ pip install --pre pathogena
 ```
 
 ## Using a local development server
-## pahtogena portal runs on port 8000, whilst the upload-api runs on 3000
+## pathogena portal runs on port 8000, whilst the upload-api runs on 8003
 
 ```bash
 export PATHOGENA_HOST="localhost:8000"

--- a/src/pathogena/batch_upload_apis.py
+++ b/src/pathogena/batch_upload_apis.py
@@ -223,7 +223,9 @@ class UploadAPIClient:
         Raises:
             APIError: If the API returns a non-2xx status code.
         """
-        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end/"
+        url = (
+            f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end/"
+        )
         try:
             response = self.client.post(
                 url,

--- a/src/pathogena/batch_upload_apis.py
+++ b/src/pathogena/batch_upload_apis.py
@@ -5,7 +5,6 @@ import httpx
 
 from pathogena.constants import DEFAULT_HOST, DEFAULT_PROTOCOL, DEFAULT_UPLOAD_HOST
 from pathogena.errors import APIError
-from pathogena.log_utils import httpx_hooks
 from pathogena.util import get_access_token
 
 
@@ -143,13 +142,13 @@ class UploadAPIClient:
 
     def batches_uploads_start_file_upload(
         self,
-        batch_pk: int,
+        batch_pk: str,
         data: dict[str, Any] | None = None,
     ) -> httpx.Response:
         """Starts an upload by making a POST request.
 
         Args:
-            batch_pk (int): The primary key of the batch.
+            batch_pk (str): The primary key of the batch.
             data (dict[str, Any] | None): Data to include in the POST request body.
 
         Returns:
@@ -243,13 +242,13 @@ class UploadAPIClient:
 
     def batches_samples_end_upload_session_create(
         self,
-        batch_pk: int,
+        batch_pk: str,
         upload_session: int | None = None,
     ) -> httpx.Response:
         """Ends a sample upload session by making a POST request to the backend.
 
         Args:
-            batch_pk (int): The primary key of the batch.
+            batch_pk (str): The primary key of the batch.
             data (dict[str, Any] | None): Data to include in the POST request body.
 
 

--- a/src/pathogena/batch_upload_apis.py
+++ b/src/pathogena/batch_upload_apis.py
@@ -54,7 +54,7 @@ def get_upload_host(cli_host: str | None = None) -> str:
     )
 
 
-class APIClient:
+class UploadAPIClient:
     """A class to handle API requests for batch uploads and related operations."""
 
     def __init__(
@@ -74,7 +74,6 @@ class APIClient:
         self.token = get_access_token(get_host())
         self.upload_session = upload_session
 
-    # create batch
     def batches_create(
         self,
         data: dict[str, Any] | None = None,
@@ -106,7 +105,6 @@ class APIClient:
                 f"Failed to create: {response.text}", response.status_code
             ) from e
 
-    ## start upload session for a batches samples
     def batches_samples_start_upload_session_create(
         self,
         batch_pk: int,
@@ -143,13 +141,12 @@ class APIClient:
                 response.status_code,
             ) from e
 
-    # start batch upload
-    def batches_uploads_start_create(
+    def batches_uploads_start_file_upload(
         self,
         batch_pk: int,
         data: dict[str, Any] | None = None,
     ) -> httpx.Response:
-        """Starts a upload by making a POST request.
+        """Starts an upload by making a POST request.
 
         Args:
             batch_pk (int): The primary key of the batch.
@@ -161,7 +158,7 @@ class APIClient:
         Raises:
             APIError: If the API returns a non-2xx status code.
         """
-        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/start/"
+        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/start-file-upload/"
         try:
             response = self.client.post(
                 url,
@@ -177,8 +174,7 @@ class APIClient:
                 response.status_code,
             ) from e
 
-    # start a chunking session
-    def batches_uploads_upload_chunk_create(
+    def batches_uploads_upload_chunk(
         self,
         batch_pk: int,
         data: dict[str, Any] | None = None,
@@ -211,8 +207,7 @@ class APIClient:
                 response.status_code,
             ) from e
 
-    # end batch upload
-    def batches_uploads_end_create(
+    def batches_uploads_end_file_upload(
         self,
         batch_pk: int,
         data: dict[str, Any] | None = None,
@@ -230,7 +225,7 @@ class APIClient:
             APIError: If the API returns a non-2xx status code.
         """
         url = (
-            f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end/"
+            f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end-file-upload/"
         )
         try:
             response = self.client.post(
@@ -246,7 +241,6 @@ class APIClient:
                 f"Failed to end batch upload: {response.text}", response.status_code
             ) from e
 
-    ## end upload session for a batches samples
     def batches_samples_end_upload_session_create(
         self,
         batch_pk: int,

--- a/src/pathogena/batch_upload_apis.py
+++ b/src/pathogena/batch_upload_apis.py
@@ -157,7 +157,7 @@ class UploadAPIClient:
         Raises:
             APIError: If the API returns a non-2xx status code.
         """
-        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/start-file-upload/"
+        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/start/"
         try:
             response = self.client.post(
                 url,
@@ -223,7 +223,7 @@ class UploadAPIClient:
         Raises:
             APIError: If the API returns a non-2xx status code.
         """
-        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end-file-upload/"
+        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end/"
         try:
             response = self.client.post(
                 url,

--- a/src/pathogena/batch_upload_apis.py
+++ b/src/pathogena/batch_upload_apis.py
@@ -223,9 +223,7 @@ class UploadAPIClient:
         Raises:
             APIError: If the API returns a non-2xx status code.
         """
-        url = (
-            f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end-file-upload/"
-        )
+        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/uploads/end-file-upload/"
         try:
             response = self.client.post(
                 url,

--- a/src/pathogena/batch_upload_apis.py
+++ b/src/pathogena/batch_upload_apis.py
@@ -123,7 +123,7 @@ class UploadAPIClient:
         Raises:
             APIError: If the API returns a non-2xx status code.
         """
-        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/samples/start-upload-session/"
+        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/sample-files/start-upload-session/"
         try:
             response = self.client.post(
                 url,
@@ -264,7 +264,7 @@ class UploadAPIClient:
         else:
             data = {"upload_session": self.upload_session}
 
-        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/samples/end-upload-session/"
+        url = f"{get_protocol()}://{self.base_url}/api/v1/batches/{batch_pk}/sample-files/end-upload-session/"
         try:
             response = self.client.post(
                 url,

--- a/src/pathogena/cli.py
+++ b/src/pathogena/cli.py
@@ -305,10 +305,10 @@ def download(
 def query_raw(samples: str, *, host: str | None = None) -> None:
     """Fetch metadata for one or more SAMPLES in JSON format.
 
-    SAMPLES should be command separated list of GUIDs or path to mapping CSV.
+    The provided SAMPLES should be a comma-separated list of GUIDs, or path to a mapping CSV.
 
     Args:
-        samples (str): Command separated list of GUIDs or path to mapping CSV.
+        samples (str): Comma-separated list of GUIDs, or a path to a mapping CSV.
         host (str | None): The host server.
     """
     host = lib.get_host(host)

--- a/src/pathogena/lib.py
+++ b/src/pathogena/lib.py
@@ -342,7 +342,7 @@ def upload_batch(
     prepared_files = prepare_files(
         batch_pk=int(batch_id),
         files=batch.samples,
-        api_client=batch_upload_apis.APIClient(),
+        api_client=batch_upload_apis.UploadAPIClient(),
     )
 
     # initialise class
@@ -378,7 +378,7 @@ def upload_batch(
     upload_utils.upload_fastq(
         upload_data=upload_file_type,
         prepared_files=prepared_files,
-        api_client=batch_upload_apis.APIClient(),
+        api_client=batch_upload_apis.UploadAPIClient(),
         sample_uploads=batch_status.get("samples"),
     )
 

--- a/src/pathogena/lib.py
+++ b/src/pathogena/lib.py
@@ -341,7 +341,7 @@ def upload_batch(
 
     prepared_files = prepare_files(
         batch_pk=int(batch_id),
-        files=batch.samples,
+        samples=batch.samples,
         api_client=batch_upload_apis.UploadAPIClient(),
     )
 
@@ -360,8 +360,9 @@ def upload_batch(
         mapping_csv_records.append(
             {
                 "batch_name": upload_session_name,
-                "sample_name": file["file"]["name"],
-                "remote_sample_name": file["sample_id"],
+                "file_name": file["file"]["name"],
+                "remote_sample_id": file["sample_id"],
+                "remote_sample_name": file["sample_file_id"],
                 "remote_batch_name": batch_name,
                 "remote_batch_id": batch_id,
             }
@@ -373,13 +374,10 @@ def upload_batch(
         f"{get_protocol()}://{host}/batches/{legacy_batch_id}"
     )
 
-    batch_status = get_batch_upload_status(batch_id)
-
     upload_utils.upload_fastq(
         upload_data=upload_file_type,
         prepared_files=prepared_files,
         api_client=batch_upload_apis.UploadAPIClient(),
-        sample_uploads=batch_status.get("samples"),
     )
 
     if not save:

--- a/src/pathogena/upload_utils.py
+++ b/src/pathogena/upload_utils.py
@@ -505,7 +505,7 @@ def prepare_files(
                         batch_pk=batch_pk,
                         upload_session=upload_session,
                         sample_id=sample_id,
-                        api_client=api_client
+                        api_client=api_client,
                     )
             if file_ready:
                 selected_files.append(file_ready)

--- a/src/pathogena/upload_utils.py
+++ b/src/pathogena/upload_utils.py
@@ -444,6 +444,7 @@ def prepare_files(
     sample_summaries = session_response["sample_summaries"]
 
     # assume order is consistent and map out the sample summaries to the files
+    # ie. illumina samples have two files and ont samples have one
     per_file_sample_summaries = (
         [item for item in sample_summaries for _ in range(2)]
         if len(sample_summaries) * 2 == len(files_to_upload)

--- a/src/pathogena/upload_utils.py
+++ b/src/pathogena/upload_utils.py
@@ -13,7 +13,7 @@ import httpx
 from httpx import Response, codes
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
-from pathogena.batch_upload_apis import UploadAPIClient, APIError
+from pathogena.batch_upload_apis import APIError, UploadAPIClient
 from pathogena.constants import (
     DEFAULT_CHUNK_SIZE,
     DEFAULT_HOST,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -2,28 +2,27 @@ from collections.abc import Callable, Generator
 from concurrent.futures import Future
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import httpx
 import pytest
 from pytest_mock import MockerFixture
-from pytest_mock.plugin import _mocker
 
 from pathogena.batch_upload_apis import UploadAPIClient, APIError
 from pathogena.upload_utils import (
     OnComplete,
     OnProgress,
     PreparedFiles,
-    SampleFileMetadata,
-    SampleFileUploadStatus,
     SelectedFile,
-    UploadFileType,
+    UploadData,
     UploadSample,
     prepare_file,
     prepare_files,
-    upload_chunk,
     upload_chunks,
     upload_files,
+    SampleFileMetadata,
+    SampleFileUploadStatus,
+    UploadMetrics,
 )
 
 
@@ -35,15 +34,13 @@ def mock_api_client(mocker: Callable[..., Generator[MockerFixture, None, None]])
 class TestPrepareFile:
     @pytest.fixture(autouse=True)
     def setup(self, mocker: Callable[..., Generator[MockerFixture, None, None]]):
-        file = {
-            "name": "file1.txt",
-            "size": 1024,  # 1 KB
-            "control": "false",
-            "content_type": "text/plain",
-        }
-
-        # cast into SampleMetadat
-        self.file = cast("SampleFileMetadata", file)
+        self.file = SampleFileMetadata(
+            name="file1.txt",
+            size=1024,  # 1 KB
+            control="false",
+            content_type="text/plain",
+            specimen_organism="mycobacteria"
+        )
 
         self.mock_reads_file1_data = mocker.MagicMock()
         self.mock_reads_file1_data.return_value = b"\x1f\x8b\x08\x08\x22\x4e\x01"
@@ -64,18 +61,19 @@ class TestPrepareFile:
             is_ont=False,
             # read_file1_data=self.mock_reads_file1_data,
         )
+        self.sample_id = "99999999-9999-9999-9999-999999999999"
 
         # Ensure `reads_1_resolved_path` is set
         self.upload_data.reads_1_resolved_path = self.upload_data.reads_1
         # set values to call prepare files
-        self.batch_pk = 1
+        self.batch_pk = "11111111-1111-1111-1111-111111111111"
         self.upload_session = 1234
         self.file_data = b"\x1f\x8b\x08\x08\x22\x4e\x01"
 
     def test_prepare_file_success(self, mock_api_client: Any):
         # mock successful api response
         mock_api_client.batches_uploads_start_file_upload.return_value = httpx.Response(
-            status_code=httpx.codes.OK, json={"upload_id": "abc123", "sample_id": 456}
+            status_code=httpx.codes.OK, json={"upload_id": "abc123", "sample_id": "99999999-9999-9999-9999-999999999999", "sample_file_id": 456}
         )
 
         # call
@@ -85,14 +83,16 @@ class TestPrepareFile:
             batch_pk=self.batch_pk,
             upload_session=self.upload_session,
             api_client=mock_api_client,
+            sample_id=self.sample_id,
             chunk_size=5000000,
         )
 
         assert result == {
             "file": self.file,
             "upload_id": "abc123",
-            "batch_id": 1,
-            "sample_id": 456,
+            "batch_id": "11111111-1111-1111-1111-111111111111",
+            "sample_id": "99999999-9999-9999-9999-999999999999",
+            "sample_file_id": 456,
             "total_chunks": 1,  # 1024/5000000 = 0.0002, rounds to 1 chunk
             "upload_session": 1234,
             "file_data": b"\x1f\x8b\x08\x08\x22\x4e\x01",
@@ -110,6 +110,7 @@ class TestPrepareFile:
             file=self.file,
             batch_pk=self.batch_pk,
             upload_session=self.upload_session,
+            sample_id=self.sample_id,
             api_client=mock_api_client,
             chunk_size=5000000,
         )
@@ -131,6 +132,7 @@ class TestPrepareFile:
             file=self.file,
             batch_pk=self.batch_pk,
             upload_session=self.upload_session,
+            sample_id=self.sample_id,
             api_client=mock_api_client,
             chunk_size=5000000,
         )
@@ -176,6 +178,12 @@ class TestPrepareFiles:
         self.batch_pk = 1
         self.instrument_code = "INST001"
         self.upload_session = 123
+        self.sample_summaries = [
+            dict(sample_id="11111111-1111-1111-1111-111111111111"),
+            dict(sample_id="11111111-1111-1111-1111-111111111111"),
+            dict(sample_id="22222222-2222-2222-2222-222222222222"),
+            dict(sample_id="22222222-2222-2222-2222-222222222222"),
+        ]
 
     @pytest.fixture
     def mock_api_client(
@@ -192,6 +200,7 @@ class TestPrepareFiles:
         # mock a successful start upload session  response
         mock_api_client.batches_samples_start_upload_session_create.return_value = {
             "upload_session": self.upload_session,
+            "sample_summaries": self.sample_summaries,
         }
         # mock prepare_file with successful preparation of new files
         mocker.patch(
@@ -228,51 +237,50 @@ class TestPrepareFiles:
 
         # list of files to pass to prepare_files
         files = [self.file1, self.file2]
-
-        # prepare sample_uploads for prepare_files
         sample_file_uploads = {
-            "sample_file1": {
-                "batch": 123,
-                "file_path": Path("reads/tuberculosis_1_1.fastq.gz"),
-                "uploaded_file_name": "tuberculosis_1_1.fastq.gz",
-                "created_at": datetime(2024, 12, 10, 12, 00, 00),
-                "upload_status": "COMPLETE",
-                "upload_id": "abc123",
-                "total_chunks": 2,
-                "metrics": {
-                    "chunks_received": 1,
-                    "chunks_total": 2,
-                    "upload_status": "COMPLETE",
-                    "percentage_complete": 50.0,
-                    "upload_speed": 10.0,
-                    "time_remaining": 10.0,
-                    "estimated_completion_time": datetime(2024, 12, 10, 12, 10, 00),
-                },
-            },
-            "sample_file2": {
-                "batch": 123,
-                "file_path": Path("reads/tuberculosis_1_2.fastq.gz"),
-                "uploaded_file_name": "tuberculosis_1_2.fastq.gz",
-                "created_at": datetime(2024, 12, 10, 12, 00, 00),
-                "upload_status": "IN_PROGRESS",
-                "upload_id": "def456",
-                "total_chunks": 4,
-                "metrics": {
-                    "chunks_received": 1,
-                    "chunks_total": 4,
-                    "upload_status": "IN_PROGRESS",
-                    "percentage_complete": 25.0,
-                    "upload_speed": 10.0,
-                    "time_remaining": 20.0,
-                    "estimated_completion_time": datetime(2024, 12, 10, 12, 20, 00),
-                },
-            },
+            "sample_file1": SampleFileUploadStatus(
+                id=1,
+                legacy_sample_id="11111111111111111111111111111111",
+                generated_name="SampleFile1",
+                batch=123,
+                file_path="reads/tuberculosis_1_1.fastq.gz",
+                uploaded_file_name="tuberculosis_1_1.fastq.gz",
+                created_at=datetime(2024, 12, 10, 12, 0, 0),
+                upload_status="COMPLETE",
+                upload_id="abc123",
+                total_chunks=2,
+                metrics=UploadMetrics(
+                    chunks_received=1,
+                    chunks_total=2,
+                    upload_status="COMPLETE",
+                    percentage_complete=50.0,
+                    upload_speed=10.0,
+                    time_remaining=10.0,
+                    estimated_completion_time=datetime(2024, 12, 10, 12, 10, 0),
+                ),
+            ),
+            "sample_file2": SampleFileUploadStatus(
+                id=2,
+                legacy_sample_id="22222222222222222222222222222222",
+                generated_name="SampleFile2",
+                batch=123,
+                file_path="reads/tuberculosis_1_2.fastq.gz",
+                uploaded_file_name="tuberculosis_1_2.fastq.gz",
+                created_at=datetime(2024, 12, 10, 12, 0, 0),
+                upload_status="IN_PROGRESS",
+                upload_id="def456",
+                total_chunks=4,
+                metrics=UploadMetrics(
+                    chunks_received=1,
+                    chunks_total=4,
+                    upload_status="IN_PROGRESS",
+                    percentage_complete=25.0,
+                    upload_speed=10.0,
+                    time_remaining=20.0,
+                    estimated_completion_time=datetime(2024, 12, 10, 12, 20, 0),
+                ),
+            ),
         }
-
-        # cast sample uploads to dict[str,SampleUploadStatus]
-        sample_uploads = cast("dict[str, SampleFileUploadStatus]", sample_file_uploads)
-
-        # call prepare_files
         result = prepare_files(
             self.batch_pk,
             files,
@@ -333,7 +341,7 @@ class TestUploadChunks:
         # mock as_completed to simulate completed futures
         self.mock_end_upload = mocker.patch.object(
             UploadAPIClient,
-            "batches_uploads_end_create",
+            "batches_uploads_end_file_upload",
             return_value=httpx.Response(
                 status_code=httpx.codes.OK,
             ),
@@ -360,7 +368,7 @@ class TestUploadChunks:
                 is_ont=False,
             ),
         ]
-        return UploadFileType(
+        return UploadData(
             access_token="access_token",
             batch_pk=123,
             env="env",
@@ -394,7 +402,7 @@ class TestUploadChunks:
 
     def test_upload_chunks_success(
         self,
-        mock_upload_data: UploadFileType,
+        mock_upload_data: UploadData,
         mock_file: SelectedFile,
         mock_file_status: dict,
         mocker: Callable[..., Generator[MockerFixture, None, None]],
@@ -407,13 +415,13 @@ class TestUploadChunks:
             # side_effect=mock_upload_success,
         )
         mock_client = mocker.patch(
-            "pathogena.upload_utils.APIClient",
+            "pathogena.upload_utils.UploadAPIClient",
         )
-        mock_batches_uploads_end_create = mocker.MagicMock()
-        mock_batches_uploads_end_create.side_effect = httpx.Response(
+        mock_batches_uploads_end_file_upload = mocker.MagicMock()
+        mock_batches_uploads_end_file_upload.side_effect = httpx.Response(
             200, json={"metrics": "some_metrics"}
         )
-        mock_client.batches_uploads_end_file_upload = mock_batches_uploads_end_create
+        mock_client.batches_uploads_end_file_upload = mock_batches_uploads_end_file_upload
 
         upload_chunks(mock_upload_data, mock_file, mock_file_status)
 
@@ -425,11 +433,11 @@ class TestUploadChunks:
             mock_file_status[mock_file.get("upload_id")]["chunks_uploaded"]
             == mock_file["total_chunks"]
         )
-        assert self.mock_end_upload.calledonce  # batches_uploads_end_create called once
+        assert self.mock_end_upload.calledonce  # batches_uploads_end_file_upload called once
 
     def test_upload_chunks_retry_on_400(
         self,
-        mock_upload_data: UploadFileType,
+        mock_upload_data: UploadData,
         mock_file: SelectedFile,
         mock_file_status: dict,
         mocker: Callable[..., Generator[MockerFixture, None, None]],
@@ -480,7 +488,7 @@ class TestUploadChunks:
         assert mock_upload_data.on_complete is None  # not completed all chunks
         assert (
             not self.mock_end_upload.called
-        )  # batches_uploads_end_create should not be called as 2nd upload failed
+        )  # batches_uploads_end_file_upload should not be called as 2nd upload failed
         assert mock_upload_chunk.call_count == 4
         assert (
             "Retrying upload of chunk 1" in caplog.text
@@ -491,7 +499,7 @@ class TestUploadChunks:
 
     def test_upload_chunks_error_handling(
         self,
-        mock_upload_data: UploadFileType,
+        mock_upload_data: UploadData,
         mock_file: SelectedFile,
         mock_file_status: dict,
         mocker: Callable[..., Generator[MockerFixture, None, None]],
@@ -520,7 +528,7 @@ class TestUploadChunks:
         assert mock_upload_data.on_complete is None  # not completed all chunks
         assert (
             not self.mock_end_upload.called
-        )  # batches_uploads_end_create should not be called since there was an error
+        )  # batches_uploads_end_file_upload should not be called since there was an error
         assert (
             "Retrying upload of chunk 0" in caplog.text
         )  # retrying upload captured in logging
@@ -560,7 +568,7 @@ class TestUploadFiles:
             ),
         ]
 
-        return UploadFileType(
+        return UploadData(
             access_token="access_token",
             batch_pk=123,
             env="env",
@@ -625,7 +633,7 @@ class TestUploadFiles:
 
     def test_upload_files_success(
         self,
-        mock_upload_data: UploadFileType,
+        mock_upload_data: UploadData,
         mock_sample_uploads: None,
         mock_api_client: Any,
         mock_successful_prepare_files: PreparedFiles,
@@ -653,7 +661,6 @@ class TestUploadFiles:
             mock_upload_data,
             prepared_files,
             mock_api_client,
-            mock_sample_uploads,
         )
 
         assert mock_upload_chunks.call_count == 2  # upload chunks called for each file
@@ -662,7 +669,7 @@ class TestUploadFiles:
 
     def test_upload_files_prepare_api_error(
         self,
-        mock_upload_data: UploadFileType,
+        mock_upload_data: UploadData,
         mock_unsuccessful_prepare_files,
         mock_sample_uploads: None,
         mock_api_client: Any,
@@ -674,7 +681,6 @@ class TestUploadFiles:
             mock_upload_data,
             mock_unsuccessful_prepare_files,
             mock_api_client,
-            mock_sample_uploads,
         )
 
         # assert correct error is logged
@@ -682,7 +688,7 @@ class TestUploadFiles:
 
     def test_upload_files_chunk_upload_error(
         self,
-        mock_upload_data: UploadFileType,
+        mock_upload_data: UploadData,
         mock_successful_prepare_files: PreparedFiles,
         mock_sample_uploads: None,
         mock_api_client: Any,
@@ -709,7 +715,7 @@ class TestUploadFiles:
 
         # call
         upload_files(
-            mock_upload_data, prepared_files, mock_api_client, mock_sample_uploads
+            mock_upload_data, prepared_files, mock_api_client
         )
 
         assert mock_upload_chunks.call_count == 2  # upload chunks called twice

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_mock import MockerFixture
 from pytest_mock.plugin import _mocker
 
-from pathogena.batch_upload_apis import APIClient, APIError
+from pathogena.batch_upload_apis import UploadAPIClient, APIError
 from pathogena.upload_utils import (
     OnComplete,
     OnProgress,
@@ -29,7 +29,7 @@ from pathogena.upload_utils import (
 
 @pytest.fixture
 def mock_api_client(mocker: Callable[..., Generator[MockerFixture, None, None]]):
-    return mocker.MagicMock(spec=APIClient)
+    return mocker.MagicMock(spec=UploadAPIClient)
 
 
 class TestPrepareFile:
@@ -74,7 +74,7 @@ class TestPrepareFile:
 
     def test_prepare_file_success(self, mock_api_client: Any):
         # mock successful api response
-        mock_api_client.batches_uploads_start_create.return_value = httpx.Response(
+        mock_api_client.batches_uploads_start_file_upload.return_value = httpx.Response(
             status_code=httpx.codes.OK, json={"upload_id": "abc123", "sample_id": 456}
         )
 
@@ -100,7 +100,7 @@ class TestPrepareFile:
 
     def test_prepare_file_unsuccessful(self, mock_api_client: Any):
         # mock api response with 400 code
-        mock_api_client.batches_uploads_start_create.return_value = httpx.Response(
+        mock_api_client.batches_uploads_start_file_upload.return_value = httpx.Response(
             status_code=httpx.codes.BAD_REQUEST, json={"error": "Bad Request"}
         )
 
@@ -121,7 +121,7 @@ class TestPrepareFile:
 
     def test_prepare_file_apierror(self, mock_api_client: Any):
         # mock api response
-        mock_api_client.batches_uploads_start_create.side_effect = APIError(
+        mock_api_client.batches_uploads_start_file_upload.side_effect = APIError(
             "API request failed", 500
         )
 
@@ -182,7 +182,7 @@ class TestPrepareFiles:
         self, mocker: Callable[..., Generator[MockerFixture, None, None]]
     ):
         """Fixture for mocking the APIClient."""
-        return mocker.MagicMock(spec=APIClient)
+        return mocker.MagicMock(spec=UploadAPIClient)
 
     def test_prepare_files_success(
         self,
@@ -334,7 +334,7 @@ class TestUploadChunks:
 
         # mock as_completed to simulate completed futures
         self.mock_end_upload = mocker.patch.object(
-            APIClient,
+            UploadAPIClient,
             "batches_uploads_end_create",
             return_value=httpx.Response(
                 status_code=httpx.codes.OK,
@@ -415,7 +415,7 @@ class TestUploadChunks:
         mock_batches_uploads_end_create.side_effect = httpx.Response(
             200, json={"metrics": "some_metrics"}
         )
-        mock_client.batches_uploads_end_create = mock_batches_uploads_end_create
+        mock_client.batches_uploads_end_file_upload = mock_batches_uploads_end_create
 
         upload_chunks(mock_upload_data, mock_file, mock_file_status)
 
@@ -586,7 +586,7 @@ class TestUploadFiles:
         self, mocker: Callable[..., Generator[MockerFixture, None, None]]
     ):
         """Fixture for mocking the APIClient."""
-        return mocker.MagicMock(spec=APIClient)
+        return mocker.MagicMock(spec=UploadAPIClient)
 
     @pytest.fixture
     def mock_successful_prepare_files(self) -> PreparedFiles:
@@ -643,7 +643,7 @@ class TestUploadFiles:
 
         # mock successful API client response
         mocker.patch.object(
-            APIClient,
+            UploadAPIClient,
             "batches_samples_end_upload_session_create",
             return_value=httpx.Response(
                 status_code=httpx.codes.OK,
@@ -702,7 +702,7 @@ class TestUploadFiles:
 
         # mock successful API client response
         mocker.patch.object(
-            APIClient,
+            UploadAPIClient,
             "batches_samples_end_upload_session_create",
             return_value=httpx.Response(
                 status_code=httpx.codes.OK,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -39,7 +39,7 @@ class TestPrepareFile:
             size=1024,  # 1 KB
             control="false",
             content_type="text/plain",
-            specimen_organism="mycobacteria"
+            specimen_organism="mycobacteria",
         )
 
         self.mock_reads_file1_data = mocker.MagicMock()
@@ -73,7 +73,12 @@ class TestPrepareFile:
     def test_prepare_file_success(self, mock_api_client: Any):
         # mock successful api response
         mock_api_client.batches_uploads_start_file_upload.return_value = httpx.Response(
-            status_code=httpx.codes.OK, json={"upload_id": "abc123", "sample_id": "99999999-9999-9999-9999-999999999999", "sample_file_id": 456}
+            status_code=httpx.codes.OK,
+            json={
+                "upload_id": "abc123",
+                "sample_id": "99999999-9999-9999-9999-999999999999",
+                "sample_file_id": 456,
+            },
         )
 
         # call
@@ -421,7 +426,9 @@ class TestUploadChunks:
         mock_batches_uploads_end_file_upload.side_effect = httpx.Response(
             200, json={"metrics": "some_metrics"}
         )
-        mock_client.batches_uploads_end_file_upload = mock_batches_uploads_end_file_upload
+        mock_client.batches_uploads_end_file_upload = (
+            mock_batches_uploads_end_file_upload
+        )
 
         upload_chunks(mock_upload_data, mock_file, mock_file_status)
 
@@ -433,7 +440,9 @@ class TestUploadChunks:
             mock_file_status[mock_file.get("upload_id")]["chunks_uploaded"]
             == mock_file["total_chunks"]
         )
-        assert self.mock_end_upload.calledonce  # batches_uploads_end_file_upload called once
+        assert (
+            self.mock_end_upload.calledonce
+        )  # batches_uploads_end_file_upload called once
 
     def test_upload_chunks_retry_on_400(
         self,
@@ -526,9 +535,7 @@ class TestUploadChunks:
 
         assert mock_upload_data.on_progress is None  # no progress, errors before
         assert mock_upload_data.on_complete is None  # not completed all chunks
-        assert (
-            not self.mock_end_upload.called
-        )  # batches_uploads_end_file_upload should not be called since there was an error
+        assert not self.mock_end_upload.called  # batches_uploads_end_file_upload should not be called since there was an error
         assert (
             "Retrying upload of chunk 0" in caplog.text
         )  # retrying upload captured in logging
@@ -714,9 +721,7 @@ class TestUploadFiles:
         )
 
         # call
-        upload_files(
-            mock_upload_data, prepared_files, mock_api_client
-        )
+        upload_files(mock_upload_data, prepared_files, mock_api_client)
 
         assert mock_upload_chunks.call_count == 2  # upload chunks called twice
         assert (

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -8,21 +8,21 @@ import httpx
 import pytest
 from pytest_mock import MockerFixture
 
-from pathogena.batch_upload_apis import UploadAPIClient, APIError
+from pathogena.batch_upload_apis import APIError, UploadAPIClient
 from pathogena.upload_utils import (
     OnComplete,
     OnProgress,
     PreparedFiles,
+    SampleFileMetadata,
+    SampleFileUploadStatus,
     SelectedFile,
     UploadData,
+    UploadMetrics,
     UploadSample,
     prepare_file,
     prepare_files,
     upload_chunks,
     upload_files,
-    SampleFileMetadata,
-    SampleFileUploadStatus,
-    UploadMetrics,
 )
 
 
@@ -184,10 +184,10 @@ class TestPrepareFiles:
         self.instrument_code = "INST001"
         self.upload_session = 123
         self.sample_summaries = [
-            dict(sample_id="11111111-1111-1111-1111-111111111111"),
-            dict(sample_id="11111111-1111-1111-1111-111111111111"),
-            dict(sample_id="22222222-2222-2222-2222-222222222222"),
-            dict(sample_id="22222222-2222-2222-2222-222222222222"),
+            {"sample_id": "11111111-1111-1111-1111-111111111111"},
+            {"sample_id": "11111111-1111-1111-1111-111111111111"},
+            {"sample_id": "22222222-2222-2222-2222-222222222222"},
+            {"sample_id": "22222222-2222-2222-2222-222222222222"},
         ]
 
     @pytest.fixture

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -14,8 +14,8 @@ from pathogena.upload_utils import (
     OnComplete,
     OnProgress,
     PreparedFiles,
-    SampleMetadata,
-    SampleUploadStatus,
+    SampleFileMetadata,
+    SampleFileUploadStatus,
     SelectedFile,
     UploadFileType,
     UploadSample,
@@ -43,7 +43,7 @@ class TestPrepareFile:
         }
 
         # cast into SampleMetadat
-        self.file = cast("SampleMetadata", file)
+        self.file = cast("SampleFileMetadata", file)
 
         self.mock_reads_file1_data = mocker.MagicMock()
         self.mock_reads_file1_data.return_value = b"\x1f\x8b\x08\x08\x22\x4e\x01"
@@ -230,8 +230,8 @@ class TestPrepareFiles:
         files = [self.file1, self.file2]
 
         # prepare sample_uploads for prepare_files
-        sample_uploads = {
-            "sample1": {
+        sample_file_uploads = {
+            "sample_file1": {
                 "batch": 123,
                 "file_path": Path("reads/tuberculosis_1_1.fastq.gz"),
                 "uploaded_file_name": "tuberculosis_1_1.fastq.gz",
@@ -239,7 +239,6 @@ class TestPrepareFiles:
                 "upload_status": "COMPLETE",
                 "upload_id": "abc123",
                 "total_chunks": 2,
-                "hyphenated_legacy_sample_id": "sample-123",
                 "metrics": {
                     "chunks_received": 1,
                     "chunks_total": 2,
@@ -250,7 +249,7 @@ class TestPrepareFiles:
                     "estimated_completion_time": datetime(2024, 12, 10, 12, 10, 00),
                 },
             },
-            "sample2": {
+            "sample_file2": {
                 "batch": 123,
                 "file_path": Path("reads/tuberculosis_1_2.fastq.gz"),
                 "uploaded_file_name": "tuberculosis_1_2.fastq.gz",
@@ -258,7 +257,6 @@ class TestPrepareFiles:
                 "upload_status": "IN_PROGRESS",
                 "upload_id": "def456",
                 "total_chunks": 4,
-                "hyphenated_legacy_sample_id": "sample-456",
                 "metrics": {
                     "chunks_received": 1,
                     "chunks_total": 4,
@@ -272,14 +270,14 @@ class TestPrepareFiles:
         }
 
         # cast sample uploads to dict[str,SampleUploadStatus]
-        sample_uploads = cast("dict[str, SampleUploadStatus]", sample_uploads)
+        sample_uploads = cast("dict[str, SampleFileUploadStatus]", sample_file_uploads)
 
         # call prepare_files
         result = prepare_files(
             self.batch_pk,
             files,
             mock_api_client,
-            sample_uploads,
+            sample_file_uploads,
         )
 
         assert len(result["files"]) == 1  # file1.txt is complete and so is skipped


### PR DESCRIPTION
This PR isn't quite finished because it's not utilising the created logical sample IDs between the session start and the file start. It should be a pretty quick job but it's been on the backburner today after I broke the pathogen-app again. Leave this unreviewed, I will finish it off on Monday 28th April when I return. The related PRs are:
- pathogena-app https://github.com/GlobalPathogenAnalysisService/pathogena-app/pull/380
- pathogena-upload-api https://github.com/GlobalPathogenAnalysisService/pathogena-upload-api/pull/203
- client https://github.com/EIT-Pathogena/client/pull/30