### PR TITLE
docs: add missing build-csv section and fix broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 2.1.1 (2025-05-27)
+
+### Chore
+
+- Updated cli documentations and fixed broken links.
+
 ## 2.1.0 (2025-01-22)
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Bioconda-based build against latest PyPI release
 # Created for a specific user. Not part of the pypi release process
 FROM condaforge/miniforge3:latest
-ENV PATHOGENA_CLIENT_VERSION=2.0.0
+ENV PATHOGENA_CLIENT_VERSION=2.1.1
 RUN mamba install -c bioconda hostile==1.1.0
 RUN pip install https://pypi.io/packages/source/g/pathogena/pathogena-${PATHOGENA_CLIENT_VERSION}.tar.gz

--- a/README_pypi.md
+++ b/README_pypi.md
@@ -47,6 +47,7 @@ The client requires the Conda platform to be using `x86_64` when creating the en
     ```
 
 ### Installing or updating the client with Miniconda
+<a id="installing-or-updating-the-client-with-miniconda"></a>
 
 The client has at least one dependency that requires `bioconda`, which itself
 depends on `conda-forge`. Note that for the `conda create` step (see below), installation can be very slow,
@@ -179,6 +180,7 @@ pathogena balance
 15:56:57 INFO: Your remaining account balance is 1000 credits
 ```
 ## `pathogena upload`
+<a id="pathogena-upload"></a>
 
 ```text
 Usage: pathogena upload [OPTIONS] UPLOAD_CSV
@@ -204,7 +206,7 @@ best practice to minimise the risk of personally identifiable information being 
 The upload command performs metadata validation and client-side removal of human reads for each of your samples,
 before uploading sequences to EIT Pathogena for analysis.
 
-To generate a CSV file to use with this command see the [build-csv](./build-csv.md) documentation. 
+To generate a CSV file to use with this command see the [build-csv](#pathogena-build-csv) documentation.
 
 ### Credits
 
@@ -213,7 +215,7 @@ header of the Pathogena Portal or by using the `pathogena balance` command. More
 `pathogena balance` section.
 
 Each sample for Mycobacterium genomic sequencing will require 10 credits whereas SARS-CoV-2 sample sequencing will require 1 credits.
-During the upload command process, a balance check is performed to ensure the user has enough credits for the number of samples in the batch. 
+During the upload command process, a balance check is performed to ensure the user has enough credits for the number of samples in the batch.
 Credits are then deducted when sample files are successfully uploaded and ready for processing.
 
 ### Human Read Removal
@@ -280,6 +282,43 @@ pathogena upload --skip-decontamination my-first-batch.csv
 15:49:21 INFO: Getting credit balance for portal.eit-pathogena.com
 15:49:23 INFO: Your remaining account balance is 990 credits
 ```
+## `pathogena build-csv`
+<a id="pathogena-build-csv"></a>
+
+```text
+Usage: pathogena build-csv [OPTIONS] SAMPLES_FOLDER
+
+  Command to create upload csv from SAMPLES_FOLDER containing sample fastqs.
+
+  Use max_batch_size to split into multiple separate upload csvs.
+
+  Adjust the read_suffix parameters to match the file endings for your read
+  files.
+
+Options:
+  --output-csv FILE               Path to output CSV file  [required]
+  --batch-name TEXT               Batch name  [required]
+  --collection-date [%Y-%m-%d]    Collection date (YYYY-MM-DD)  [default:
+                                  2024-10-24; required]
+  --country TEXT                  3-letter Country Code  [required]
+  --instrument-platform [illumina|ont]
+                                  Sequencing technology
+  --subdivision TEXT              Subdivision
+  --district TEXT                 District
+  --ont_read_suffix TEXT          Read file ending for ONT fastq files
+                                  [default: .fastq.gz]
+  --illumina_read1_suffix TEXT    Read file ending for Illumina read 1 files
+                                  [default: _1.fastq.gz]
+  --illumina_read2_suffix TEXT    Read file ending for Illumina read 2 files
+                                  [default: _2.fastq.gz]
+  --max-batch-size INTEGER        [default: 50]
+  -h, --help                      Show this message and exit.
+```
+
+This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/main/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
+
+
+Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.
 ## `pathogena decontaminate`
 
 ```text
@@ -297,7 +336,7 @@ Options:
  ```
 
 This command will attempt to remove human reads from a given input CSV file, in the same structure as the input CSV that
-would be used for uploading to EIT Pathogena, an [example can be found here](assets/example-input.csv).
+would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/main/docs/assets).
 
 By default, the processed files will be output in the same directory that the command is run in, but you can choose a
 different directory with the `--output-dir` argument.

--- a/README_pypi.md
+++ b/README_pypi.md
@@ -329,6 +329,32 @@ This command generates a CSV from a given directory of fastq sample files. An [e
 
 Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.
 
+### Usage
+
+```sh
+pathogena build-csv ~/Downloads/samples --batch-name <batch-name> --country <three-letter-country-code>
+```
+
+for ex:
+
+```sh
+pathogena build-csv ~/Downloads/samples --batch-name mybatch123 --country GBR
+```
+
+
+This will generate a CSV file in the samples folder named upload.csv, prompting users to manually fill in optional fields later (like instrument-platform, amplicon-scheme, etc.). Alternatively, these optional parameters can be passed directly via the CLI rather than filling them in manually later; the example below shows how to include some of these, but for the full list of available options, refer to `pathogena build-csv --help`.
+
+for ex:
+
+```sh
+pathogena build-csv ~/Downloads/samples \
+  --batch-name mybatch123 \
+  --country GBR \
+  --instrument-platform illumina \
+  --specimen-organism sars-cov-2 \
+  --amplicon-scheme "Automatic Detection"
+```
+
 ## `pathogena decontaminate`
 <a id="pathogena-decontaminate"></a>
 

--- a/README_pypi.md
+++ b/README_pypi.md
@@ -78,6 +78,7 @@ A simple test to verify installation would be to run a version check:
 pathogena --version
 ```
 ## `pathogena auth`
+<a id="pathogena-auth"></a>
 
 ```text
 Usage: pathogena auth [OPTIONS]
@@ -85,10 +86,9 @@ Usage: pathogena auth [OPTIONS]
   Authenticate with EIT Pathogena.
 
 Options:
-  --host                          API hostname (for development)
-  --check-expiry                   Check for a current token and print the
-                                  expiry if exists
-  -h, --help                      Show this message and exit.
+  --host TEXT     API hostname (for development)
+  --check-expiry  Check for a current token and print the expiry if exists
+  -h, --help      Show this message and exit.
 ```
 
 Most actions with the EIT Pathogena CLI require that the user have first authenticated with the EIT Pathogena server
@@ -154,11 +154,11 @@ $ pathogena auth --check-expiry
 14:05:52 INFO: EIT Pathogena client version 2.0.0rc1
 14:05:52 INFO: Current token for portal.eit-pathogena.com expires at 2024-08-13 14:04:50.672085
 ```
-## `pathogena balance`
 
-```bash balance help
-pathogena balance -h
-15:55:36 INFO: EIT Pathogena client version 2.0.0
+## `pathogena balance`
+<a id="pathogena-balance"></a>
+
+```text
 Usage: pathogena balance [OPTIONS]
 
   Check your EIT Pathogena account balance.
@@ -179,25 +179,28 @@ pathogena balance
 15:56:56 INFO: Getting credit balance for portal.eit-pathogena.com
 15:56:57 INFO: Your remaining account balance is 1000 credits
 ```
+
 ## `pathogena upload`
 <a id="pathogena-upload"></a>
 
 ```text
 Usage: pathogena upload [OPTIONS] UPLOAD_CSV
 
-  Validate, decontaminate and upload reads to EIT Pathogena. Creates a mapping
-  CSV file which can be used to download output files with original sample
-  names.
+  Validate, decontaminate and upload reads to EIT Pathogena.
+
+  Creates a mapping CSV file which can be used to download output files with
+  original sample names.
 
 Options:
-  --threads INTEGER               Number of alignment threads used during decontamination
-  --save                          Retain decontaminated reads after upload completion
-  --host                           API hostname (for development)
-  --skip-fastq-check              Skip checking FASTQ files for validity
-  --skip-decontamination          Run decontamination prior to upload
-  --output-dir DIRECTORY          Output directory for the cleaned FastQ files,
-                                  defaults to the current working directory.
-  -h, --help                      Show this message and exit.
+  --threads INTEGER       Number of alignment threads used during
+                          decontamination
+  --save                  Retain decontaminated reads after upload completion
+  --host TEXT             API hostname (for development)
+  --skip-fastq-check      Skip checking FASTQ files for validity
+  --skip-decontamination  Run decontamination prior to upload
+  --output-dir DIRECTORY  Output directory for the cleaned FastQ files,
+                          defaults to the current working directory.
+  -h, --help              Show this message and exit.
 ```
 
 > Where samples may contain human reads we strongly recommend using the provided decontamination functionality. This is
@@ -282,6 +285,7 @@ pathogena upload --skip-decontamination my-first-batch.csv
 15:49:21 INFO: Getting credit balance for portal.eit-pathogena.com
 15:49:23 INFO: Your remaining account balance is 990 credits
 ```
+
 ## `pathogena build-csv`
 <a id="pathogena-build-csv"></a>
 
@@ -299,12 +303,17 @@ Options:
   --output-csv FILE               Path to output CSV file  [required]
   --batch-name TEXT               Batch name  [required]
   --collection-date [%Y-%m-%d]    Collection date (YYYY-MM-DD)  [default:
-                                  2024-10-24; required]
+                                  2025-05-27; required]
   --country TEXT                  3-letter Country Code  [required]
   --instrument-platform [illumina|ont]
                                   Sequencing technology
-  --subdivision TEXT              Subdivision
-  --district TEXT                 District
+  --subdivision TEXT              Subdivision  [default: ""]
+  --district TEXT                 District  [default: ""]
+  --specimen-organism [mycobacteria|sars-cov-2]
+                                  Specimen organism  [default: mycobacteria]
+  --amplicon-scheme [|Automatic Detection|COVID-AMPLISEQ-V1|COVID-ARTIC-V3|COVID-ARTIC-V4.1|COVID-ARTIC-V5.0-5.2.0_1200|COVID-ARTIC-V5.0-5.3.2_400|COVID-MIDNIGHT-1200|COVID-VARSKIP-V1a-2b]
+                                  Amplicon scheme, use only when SARS-CoV-2 is
+                                  the specimen organism
   --ont_read_suffix TEXT          Read file ending for ONT fastq files
                                   [default: .fastq.gz]
   --illumina_read1_suffix TEXT    Read file ending for Illumina read 1 files
@@ -315,16 +324,18 @@ Options:
   -h, --help                      Show this message and exit.
 ```
 
-This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/2.1.0/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
+This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/2.1.1/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
 
 
 Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.
+
 ## `pathogena decontaminate`
+<a id="pathogena-decontaminate"></a>
 
 ```text
 Usage: pathogena decontaminate [OPTIONS] INPUT_CSV
 
-  Decontaminate reads from a CSV file.
+  Decontaminate reads from provided csv samples.
 
 Options:
   --output-dir DIRECTORY  Output directory for the cleaned FastQ files,
@@ -333,10 +344,10 @@ Options:
                           decontamination
   --skip-fastq-check      Skip checking FASTQ files for validity
   -h, --help              Show this message and exit.
- ```
+```
 
 This command will attempt to remove human reads from a given input CSV file, in the same structure as the input CSV that
-would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/2.1.0/docs/assets).
+would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/2.1.1/docs/assets).
 
 By default, the processed files will be output in the same directory that the command is run in, but you can choose a
 different directory with the `--output-dir` argument.
@@ -357,15 +368,17 @@ $ pathogena decontaminate tests/data/illumina.csv
 15:24:39 INFO: Cleaning complete
 15:24:39 INFO: Human reads removed from input samples and can be found here: /Users/jdhillon/code/pathogena/client
 ```
+
 ## `pathogena download`
+<a id="pathogena-download"></a>
 
 ```text
-$ pathogena download -h
-16:07:34 INFO: EIT Pathogena client version 2.0.0rc1
 Usage: pathogena download [OPTIONS] SAMPLES
 
   Download input and output files associated with sample IDs or a mapping CSV
-  file created during upload.
+  file.
+
+  That are created during upload.
 
 Options:
   --filenames TEXT        Comma-separated list of output filenames to download
@@ -408,11 +421,11 @@ pathogena download a5w2e8.mapping.csv --inputs --filenames ""
 
 The complete list of `--filenames` available for download varies by sample, and can be found in the Downloads section of
 sample view pages in EIT Pathogena.
+
 ## `pathogena validate`
+<a id="pathogena-validate"></a>
 
 ```text
-$ pathogena validate -h
-16:00:13 INFO: EIT Pathogena client version 2.0.0rc1
 Usage: pathogena validate [OPTIONS] UPLOAD_CSV
 
   Validate a given upload CSV.
@@ -426,14 +439,15 @@ The `validate` command will check that a Batch can be created from a given CSV a
 to upload the samples, the individual FastQ files are then checked for validity. These checks are already performed
 by default with the `upload` command but using this can ensure validity without commiting to the subsequent upload
 if you're looking to check a CSV during writing it.
+
 ## `pathogena query-raw`
+<a id="pathogena-query-raw"></a>
 
 ```text
-pathogena query-raw -h
-15:36:39 INFO: EIT Pathogena client version 2.0.0rc1
 Usage: pathogena query-raw [OPTIONS] SAMPLES
 
   Fetch metadata for one or more SAMPLES in JSON format.
+
   SAMPLES should be command separated list of GUIDs or path to mapping CSV.
 
 Options:
@@ -450,17 +464,19 @@ generated during upload, or one or more sample GUIDs.
 # Query all available metadata in JSON format
 pathogena query-raw a5w2e8.mapping.csv
 ```
+
 ## `pathogena query-status`
+<a id="pathogena-query-status"></a>
 
 ```text
-pathogena query-status -h
-15:36:39 INFO: EIT Pathogena client version 2.0.0rc1
 Usage: pathogena query-status [OPTIONS] SAMPLES
 
-  Fetch processing status for one or more SAMPLES in JSON format.
+  Fetch processing status for one or more SAMPLES.
+
   SAMPLES should be command separated list of GUIDs or path to mapping CSV.
 
 Options:
+  --json       Output status in JSON format
   --host TEXT  API hostname (for development)
   -h, --help   Show this message and exit.
 ```
@@ -477,7 +493,18 @@ pathogena query-status a5w2e8.mapping.csv
 # Query the processing status of a single sample
 pathogena query-status 3bf7d6f9-c883-4273-adc0-93bb96a499f6
 ```
+
 ## `pathogena autocomplete`
+<a id="pathogena-autocomplete"></a>
+
+```text
+Usage: pathogena autocomplete [OPTIONS]
+
+  Enable shell autocompletion.
+
+Options:
+  -h, --help  Show this message and exit.
+```
 
 This command will output the steps required to enable auto-completion in either a Bash or ZSH shell, follow the output
 to enable autocompletion, this will need to be executed on every new shell session, instructions are provided on how to

--- a/README_pypi.md
+++ b/README_pypi.md
@@ -315,7 +315,7 @@ Options:
   -h, --help                      Show this message and exit.
 ```
 
-This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/main/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
+This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/2.1.0/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
 
 
 Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.
@@ -336,7 +336,7 @@ Options:
  ```
 
 This command will attempt to remove human reads from a given input CSV file, in the same structure as the input CSV that
-would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/main/docs/assets).
+would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/2.1.0/docs/assets).
 
 By default, the processed files will be output in the same directory that the command is run in, but you can choose a
 different directory with the `--output-dir` argument.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,16 +1,4 @@
-## `pathogena auth`
-
-```text
-Usage: pathogena auth [OPTIONS]
-
-  Authenticate with EIT Pathogena.
-
-Options:
-  --host                          API hostname (for development)
-  --check-expiry                   Check for a current token and print the
-                                  expiry if exists
-  -h, --help                      Show this message and exit.
-```
+__help__
 
 Most actions with the EIT Pathogena CLI require that the user have first authenticated with the EIT Pathogena server
 with their login credentials. Upon successfully authentication, a bearer token is stored in the user's home directory

--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -1,4 +1,4 @@
-## `pathogena autocomplete`
+__help__
 
 This command will output the steps required to enable auto-completion in either a Bash or ZSH shell, follow the output
 to enable autocompletion, this will need to be executed on every new shell session, instructions are provided on how to

--- a/docs/balance.md
+++ b/docs/balance.md
@@ -1,16 +1,4 @@
-## `pathogena balance`
-
-```bash balance help
-pathogena balance -h
-15:55:36 INFO: EIT Pathogena client version 2.0.0
-Usage: pathogena balance [OPTIONS]
-
-  Check your EIT Pathogena account balance.
-
-Options:
-  --host TEXT  API hostname (for development)
-  -h, --help   Show this message and exit.
-```
+__help__
 
 Credits are required to upload samples and initiate the analysis process. Users can check their credit balance in the
 header of the Pathogena Portal or by using the `pathogena balance` command when logged in.

--- a/docs/build-csv.md
+++ b/docs/build-csv.md
@@ -1,35 +1,4 @@
-## `pathogena build-csv`
-<a id="pathogena-build-csv"></a>
-
-```text
-Usage: pathogena build-csv [OPTIONS] SAMPLES_FOLDER
-
-  Command to create upload csv from SAMPLES_FOLDER containing sample fastqs.
-
-  Use max_batch_size to split into multiple separate upload csvs.
-
-  Adjust the read_suffix parameters to match the file endings for your read
-  files.
-
-Options:
-  --output-csv FILE               Path to output CSV file  [required]
-  --batch-name TEXT               Batch name  [required]
-  --collection-date [%Y-%m-%d]    Collection date (YYYY-MM-DD)  [default:
-                                  2024-10-24; required]
-  --country TEXT                  3-letter Country Code  [required]
-  --instrument-platform [illumina|ont]
-                                  Sequencing technology
-  --subdivision TEXT              Subdivision
-  --district TEXT                 District
-  --ont_read_suffix TEXT          Read file ending for ONT fastq files
-                                  [default: .fastq.gz]
-  --illumina_read1_suffix TEXT    Read file ending for Illumina read 1 files
-                                  [default: _1.fastq.gz]
-  --illumina_read2_suffix TEXT    Read file ending for Illumina read 2 files
-                                  [default: _2.fastq.gz]
-  --max-batch-size INTEGER        [default: 50]
-  -h, --help                      Show this message and exit.
-```
+__help__
 
 This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/__version__/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
 

--- a/docs/build-csv.md
+++ b/docs/build-csv.md
@@ -31,7 +31,7 @@ Options:
   -h, --help                      Show this message and exit.
 ```
 
-This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/main/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
+This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/__version__/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
 
 
 Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.

--- a/docs/build-csv.md
+++ b/docs/build-csv.md
@@ -4,3 +4,29 @@ This command generates a CSV from a given directory of fastq sample files. An [e
 
 
 Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.
+
+### Usage
+
+```sh
+pathogena build-csv ~/Downloads/samples --batch-name <batch-name> --country <three-letter-country-code>
+```
+
+for ex:
+
+```sh
+pathogena build-csv ~/Downloads/samples --batch-name mybatch123 --country GBR
+```
+
+
+This will generate a CSV file in the samples folder named upload.csv, prompting users to manually fill in optional fields later (like instrument-platform, amplicon-scheme, etc.). Alternatively, these optional parameters can be passed directly via the CLI rather than filling them in manually later; the example below shows how to include some of these, but for the full list of available options, refer to `pathogena build-csv --help`.
+
+for ex:
+
+```sh
+pathogena build-csv ~/Downloads/samples \
+  --batch-name mybatch123 \
+  --country GBR \
+  --instrument-platform illumina \
+  --specimen-organism sars-cov-2 \
+  --amplicon-scheme "Automatic Detection"
+```

--- a/docs/build-csv.md
+++ b/docs/build-csv.md
@@ -1,4 +1,5 @@
 ## `pathogena build-csv`
+<a id="pathogena-build-csv"></a>
 
 ```text
 Usage: pathogena build-csv [OPTIONS] SAMPLES_FOLDER
@@ -30,7 +31,7 @@ Options:
   -h, --help                      Show this message and exit.
 ```
 
-This command generates a CSV from a given directory of fastq sample files. An [example](./assets/example-input.csv) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](./upload.md) command.
+This command generates a CSV from a given directory of fastq sample files. An [example](https://github.com/EIT-Pathogena/client/tree/main/docs/assets) of such a CSV file is given in the assets directory. A CSV file in this format is required to run the [pathogena upload](#pathogena-upload) command.
 
 
-Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.  
+Note: the CSV file must be located in the same directory as the sample.fastq files to be used with the upload command.

--- a/docs/decontaminate.md
+++ b/docs/decontaminate.md
@@ -1,18 +1,4 @@
-## `pathogena decontaminate`
-
-```text
-Usage: pathogena decontaminate [OPTIONS] INPUT_CSV
-
-  Decontaminate reads from a CSV file.
-
-Options:
-  --output-dir DIRECTORY  Output directory for the cleaned FastQ files,
-                          defaults to the current working directory.
-  --threads INTEGER       Number of alignment threads used during
-                          decontamination
-  --skip-fastq-check      Skip checking FASTQ files for validity
-  -h, --help              Show this message and exit.
- ```
+__help__
 
 This command will attempt to remove human reads from a given input CSV file, in the same structure as the input CSV that
 would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/__version__/docs/assets).

--- a/docs/decontaminate.md
+++ b/docs/decontaminate.md
@@ -15,7 +15,7 @@ Options:
  ```
 
 This command will attempt to remove human reads from a given input CSV file, in the same structure as the input CSV that
-would be used for uploading to EIT Pathogena, an [example can be found here](assets/example-input.csv).
+would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/main/docs/assets).
 
 By default, the processed files will be output in the same directory that the command is run in, but you can choose a
 different directory with the `--output-dir` argument.

--- a/docs/decontaminate.md
+++ b/docs/decontaminate.md
@@ -15,7 +15,7 @@ Options:
  ```
 
 This command will attempt to remove human reads from a given input CSV file, in the same structure as the input CSV that
-would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/main/docs/assets).
+would be used for uploading to EIT Pathogena, an [example can be found here](https://github.com/EIT-Pathogena/client/tree/__version__/docs/assets).
 
 By default, the processed files will be output in the same directory that the command is run in, but you can choose a
 different directory with the `--output-dir` argument.

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,22 +1,4 @@
-## `pathogena download`
-
-```text
-$ pathogena download -h
-16:07:34 INFO: EIT Pathogena client version 2.0.0rc1
-Usage: pathogena download [OPTIONS] SAMPLES
-
-  Download input and output files associated with sample IDs or a mapping CSV
-  file created during upload.
-
-Options:
-  --filenames TEXT        Comma-separated list of output filenames to download
-  --inputs                Also download decontaminated input FASTQ file(s)
-  --output-dir DIRECTORY  Output directory for the downloaded files.
-  --rename / --no-rename  Rename downloaded files using sample names when
-                          given a mapping CSV
-  --host TEXT             API hostname (for development)
-  -h, --help              Show this message and exit.
-```
+__help__
 
 The download command retrieves the output (and/or input) files associated with a batch of samples given a mapping CSV
 generated during upload, or one or more sample GUIDs. When a mapping CSV is used, by default downloaded file names are

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,6 +38,7 @@ The client requires the Conda platform to be using `x86_64` when creating the en
     ```
 
 ### Installing or updating the client with Miniconda
+<a id="installing-or-updating-the-client-with-miniconda"></a>
 
 The client has at least one dependency that requires `bioconda`, which itself
 depends on `conda-forge`. Note that for the `conda create` step (see below), installation can be very slow,

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,8 @@
+# EIT Pathogena Client
+
+The command line interface for the EIT Pathogena platform.
+
+The client enables privacy-preserving sequence data submission and retrieval of analytical output files. Prior to
+upload, sample identifiers are anonymised and human host sequences are removed. A computer with Linux or MacOS is
+required to use the client. When running human read removal prior to upload a computer with a modern multi-core
+processor and at least 16GB of RAM is recommended.

--- a/docs/query-raw.md
+++ b/docs/query-raw.md
@@ -1,17 +1,4 @@
-## `pathogena query-raw`
-
-```text
-pathogena query-raw -h
-15:36:39 INFO: EIT Pathogena client version 2.0.0rc1
-Usage: pathogena query-raw [OPTIONS] SAMPLES
-
-  Fetch metadata for one or more SAMPLES in JSON format.
-  SAMPLES should be command separated list of GUIDs or path to mapping CSV.
-
-Options:
-  --host TEXT  API hostname (for development)
-  -h, --help   Show this message and exit.
-```
+__help__
 
 The `query-raw` command fetches either the raw metadata of one more samples given a mapping CSV
 generated during upload, or one or more sample GUIDs.

--- a/docs/query-status.md
+++ b/docs/query-status.md
@@ -1,17 +1,4 @@
-## `pathogena query-status`
-
-```text
-pathogena query-status -h
-15:36:39 INFO: EIT Pathogena client version 2.0.0rc1
-Usage: pathogena query-status [OPTIONS] SAMPLES
-
-  Fetch processing status for one or more SAMPLES in JSON format.
-  SAMPLES should be command separated list of GUIDs or path to mapping CSV.
-
-Options:
-  --host TEXT  API hostname (for development)
-  -h, --help   Show this message and exit.
-```
+__help__
 
 The `query-status` command fetches the current processing status of one or more samples in a mapping CSV
 generated during upload, or one or more sample GUIDs.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,3 @@
+## Support
+
+For technical support, please open an issue or contact pathogena.support@eit.org

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -1,23 +1,4 @@
-## `pathogena upload`
-<a id="pathogena-upload"></a>
-
-```text
-Usage: pathogena upload [OPTIONS] UPLOAD_CSV
-
-  Validate, decontaminate and upload reads to EIT Pathogena. Creates a mapping
-  CSV file which can be used to download output files with original sample
-  names.
-
-Options:
-  --threads INTEGER               Number of alignment threads used during decontamination
-  --save                          Retain decontaminated reads after upload completion
-  --host                           API hostname (for development)
-  --skip-fastq-check              Skip checking FASTQ files for validity
-  --skip-decontamination          Run decontamination prior to upload
-  --output-dir DIRECTORY          Output directory for the cleaned FastQ files,
-                                  defaults to the current working directory.
-  -h, --help                      Show this message and exit.
-```
+__help__
 
 > Where samples may contain human reads we strongly recommend using the provided decontamination functionality. This is
 best practice to minimise the risk of personally identifiable information being uploaded to the cloud.

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -1,4 +1,5 @@
 ## `pathogena upload`
+<a id="pathogena-upload"></a>
 
 ```text
 Usage: pathogena upload [OPTIONS] UPLOAD_CSV
@@ -24,7 +25,7 @@ best practice to minimise the risk of personally identifiable information being 
 The upload command performs metadata validation and client-side removal of human reads for each of your samples,
 before uploading sequences to EIT Pathogena for analysis.
 
-To generate a CSV file to use with this command see the [build-csv](./build-csv.md) documentation. 
+To generate a CSV file to use with this command see the [build-csv](#pathogena-build-csv) documentation.
 
 ### Credits
 
@@ -33,7 +34,7 @@ header of the Pathogena Portal or by using the `pathogena balance` command. More
 `pathogena balance` section.
 
 Each sample for Mycobacterium genomic sequencing will require 10 credits whereas SARS-CoV-2 sample sequencing will require 1 credits.
-During the upload command process, a balance check is performed to ensure the user has enough credits for the number of samples in the batch. 
+During the upload command process, a balance check is performed to ensure the user has enough credits for the number of samples in the batch.
 Credits are then deducted when sample files are successfully uploaded and ready for processing.
 
 ### Human Read Removal

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -1,16 +1,4 @@
-## `pathogena validate`
-
-```text
-$ pathogena validate -h
-16:00:13 INFO: EIT Pathogena client version 2.0.0rc1
-Usage: pathogena validate [OPTIONS] UPLOAD_CSV
-
-  Validate a given upload CSV.
-
-Options:
-  --host TEXT  API hostname (for development)
-  -h, --help   Show this message and exit.
-```
+__help__
 
 The `validate` command will check that a Batch can be created from a given CSV and if your user account has permission
 to upload the samples, the individual FastQ files are then checked for validity. These checks are already performed

--- a/generate_pypi_readme.sh
+++ b/generate_pypi_readme.sh
@@ -26,3 +26,9 @@ echo "
 ## Support
 " >> README_pypi.md
 echo "For technical support, please open an issue or contact pathogena.support@eit.org" >> README_pypi.md
+
+# Extract version from __init__.py
+VERSION=$(grep '__version__' src/pathogena/__init__.py | cut -d '"' -f2)
+
+# Replace __version__ in links with actual version
+sed -i '' "s|__version__|$VERSION|g" README_pypi.md

--- a/generate_pypi_readme.sh
+++ b/generate_pypi_readme.sh
@@ -7,6 +7,8 @@
 
 # shellcheck disable=SC2028
 cat docs/intro.md > README_pypi.md
+# commitlint doesn't allow an extra EOF at the end of files, so we are adding an extra line between sections here
+echo "" >> README_pypi.md
 cat docs/install.md >> README_pypi.md
 
 commands=("auth" "balance" "upload" "build-csv" "decontaminate" "download" "validate" "query-raw" "query-status" "autocomplete")

--- a/generate_pypi_readme.sh
+++ b/generate_pypi_readme.sh
@@ -6,26 +6,26 @@
 # maintaining of documentation.
 
 # shellcheck disable=SC2028
-echo "# EIT Pathogena Client
+cat docs/intro.md > README_pypi.md
+cat docs/install.md >> README_pypi.md
 
-The command line interface for the EIT Pathogena platform.
+commands=("auth" "balance" "upload" "build-csv" "decontaminate" "download" "validate" "query-raw" "query-status" "autocomplete")
 
-The client enables privacy-preserving sequence data submission and retrieval of analytical output files. Prior to
-upload, sample identifiers are anonymised and human host sequences are removed. A computer with Linux or MacOS is
-required to use the client. When running human read removal prior to upload a computer with a modern multi-core
-processor and at least 16GB of RAM is recommended.
-" > README_pypi.md
+for i in "${commands[@]}"; do
+  COMMAND_OUTPUT=$(pathogena "$i" -h)
+  DOC_CONTENT=$(< "docs/$i.md")
+  UPDATED_DOC=$(awk -v cmd="$i" -v help="$COMMAND_OUTPUT" '{
+    if ($0 == "__help__") {
+      print "## `pathogena " cmd "`\n<a id=\"pathogena-" cmd "\"></a>\n\n```text\n" help "\n```"
+    } else {
+      print $0
+    }
+  }' <<< "$DOC_CONTENT")
+  echo "$UPDATED_DOC" >> README_pypi.md
+  echo "" >> README_pypi.md
+done
 
-docs=("install" "auth" "balance" "upload" "build-csv" "decontaminate" "download" "validate" "query-raw" "query-status" "autocomplete")
-
-for i in "${docs[@]}"; do
-  cat docs/"$i".md >> README_pypi.md;
-done;
-
-echo "
-## Support
-" >> README_pypi.md
-echo "For technical support, please open an issue or contact pathogena.support@eit.org" >> README_pypi.md
+cat docs/support.md >> README_pypi.md
 
 # Extract version from __init__.py
 VERSION=$(grep '__version__' src/pathogena/__init__.py | cut -d '"' -f2)

--- a/generate_pypi_readme.sh
+++ b/generate_pypi_readme.sh
@@ -16,7 +16,7 @@ required to use the client. When running human read removal prior to upload a co
 processor and at least 16GB of RAM is recommended.
 " > README_pypi.md
 
-docs=("install" "auth" "balance" "upload" "decontaminate" "download" "validate" "query-raw" "query-status" "autocomplete")
+docs=("install" "auth" "balance" "upload" "build-csv" "decontaminate" "download" "validate" "query-raw" "query-status" "autocomplete")
 
 for i in "${docs[@]}"; do
   cat docs/"$i".md >> README_pypi.md;

--- a/src/pathogena/__init__.py
+++ b/src/pathogena/__init__.py
@@ -1,3 +1,3 @@
 """The command line and Python client for EIT Pathogena."""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/src/pathogena/cli.py
+++ b/src/pathogena/cli.py
@@ -17,11 +17,7 @@ from pathogena.create_upload_csv import UploadData, build_upload_csv
     "--debug", is_flag=True, default=False, help="Enable verbose debug messages"
 )
 def main(*, debug: bool = False) -> None:
-    """EIT Pathogena command line interface.
-
-    Args:
-        debug (bool): Whether to enable verbose debug messages.
-    """
+    """EIT Pathogena command line interface."""
     lib.check_for_newer_version()
     util.display_cli_version()
     util.configure_debug_logging(debug)
@@ -41,12 +37,7 @@ def main(*, debug: bool = False) -> None:
     help="Check for a current token and print the expiry if exists",
 )
 def auth(*, host: str | None = None, check_expiry: bool = False) -> None:
-    """Authenticate with EIT Pathogena.
-
-    Args:
-        host (str | None): The host server.
-        check_expiry (bool): Whether to check for a current token and print the expiry if it exists.
-    """
+    """Authenticate with EIT Pathogena."""
     host = lib.get_host(host)
     if check_expiry:
         expiry = util.get_token_expiry(host)
@@ -69,11 +60,7 @@ def balance(
     *,
     host: str | None = None,
 ) -> None:
-    """Check your EIT Pathogena account balance.
-
-    Args:
-        host (str | None): The host server.
-    """
+    """Check your EIT Pathogena account balance."""
     host = lib.get_host(host)
     lib.get_credit_balance(host=host)
 
@@ -119,16 +106,7 @@ def decontaminate(
     threads: int = None,
     skip_fastq_check: bool = False,
 ) -> None:
-    """Decontaminate reads from provided csv samples.
-
-    Args:
-        samples (str): The samples to decontaminate.
-        host (str | None): The host server.
-        save (bool): Whether to retain decontaminated reads after upload completion.
-        skip_fastq_check (bool): Whether to skip checking FASTQ files for validity.
-        skip_decontamination (bool): Whether to skip the decontamination process.
-        output_dir (str): The output directory for the cleaned FastQ files.
-    """
+    """Decontaminate reads from provided csv samples."""
     batch = models.create_batch_from_csv(input_csv, skip_fastq_check)
     batch.validate_all_sample_fastqs()
     cleaned_batch_metadata = lib.decontaminate_samples_with_hostile(
@@ -188,14 +166,6 @@ def upload(
 
     Creates a mapping CSV file which can be used to download output
     files with original sample names.
-
-    Args:
-        samples (str): The samples to upload.
-        host (str | None): The host server.
-        save (bool): Whether to retain decontaminated reads after upload completion.
-        skip_fastq_check (bool): Whether to skip checking FASTQ files for validity.
-        skip_decontamination (bool): Whether to skip the decontamination process.
-        output_dir (str): The output directory for the cleaned FastQ files.
     """
     host = lib.get_host(host)
     lib.check_version_compatibility(host=host)
@@ -261,14 +231,6 @@ def download(
     """Download input and output files associated with sample IDs or a mapping CSV file.
 
     That are created during upload.
-
-    Args:
-        samples (str): The samples to download.
-        filenames (str): Comma-separated list of output filenames to download.
-        inputs (bool): Whether to also download decontaminated input FASTQ files.
-        output_dir (str): The output directory for the downloaded files.
-        rename (bool): Whether to rename downloaded files using sample names when given a mapping CSV.
-        host (str | None): The host server.
     """
     host = lib.get_host(host)
     if util.is_auth_token_live(host):
@@ -304,10 +266,6 @@ def query_raw(samples: str, *, host: str | None = None) -> None:
     """Fetch metadata for one or more SAMPLES in JSON format.
 
     SAMPLES should be command separated list of GUIDs or path to mapping CSV.
-
-    Args:
-        samples (str): Command separated list of GUIDs or path to mapping CSV.
-        host (str | None): The host server.
     """
     host = lib.get_host(host)
     if util.validate_guids(util.parse_comma_separated_string(samples)):
@@ -329,11 +287,6 @@ def query_status(samples: str, *, json: bool = False, host: str | None = None) -
     """Fetch processing status for one or more SAMPLES.
 
     SAMPLES should be command separated list of GUIDs or path to mapping CSV.
-
-    Args:
-        samples (str): Command separated list of GUIDs or path to mapping CSV.
-        json (bool): Whether to output status in JSON format.
-        host (str | None): The host server.
     """
     host = lib.get_host(host)
     if util.validate_guids(util.parse_comma_separated_string(samples)):
@@ -363,12 +316,7 @@ def download_index() -> None:
 )
 @click.option("--host", type=str, default=None, help="API hostname (for development)")
 def validate(upload_csv: Path, *, host: str | None = None) -> None:
-    """Validate a given upload CSV.
-
-    Args:
-        upload_csv (Path): The path to the upload CSV file.
-        host (str | None): The host server.
-    """
+    """Validate a given upload CSV."""
     host = lib.get_host(host)
     batch = models.create_batch_from_csv(upload_csv)
     lib.upload_batch(batch=batch, host=host, save=False, validate_only=True)
@@ -479,25 +427,11 @@ def build_csv(
     illumina_read2_suffix: str = lib.DEFAULT_METADATA["illumina_read2_suffix"],
     max_batch_size: int = lib.DEFAULT_METADATA["max_batch_size"],
 ) -> None:
-    r"""Command to create upload csv from SAMPLES_FOLDER containing sample fastqs.\n
-    Use max_batch_size to split into multiple separate upload csvs.\n
-    Adjust the read_suffix parameters to match the file endings for your read files.
+    r"""Command to create upload csv from SAMPLES_FOLDER containing sample fastqs.
 
-    Args:
-        samples_folder (str): The folder containing the FASTQ files.
-        output_csv (str): The path to the output CSV file.
-        batch_name (str): The name of the batch.
-        collection_date (str): The collection date in YYYY-MM-DD format.
-        country (str): The 3-letter country code.
-        instrument_platform (str): The sequencing technology.
-        subdivision (str): The subdivision.
-        district (str): The district.
-        pipeline (str): The specimen organism.
-        amplicon_scheme (str): The amplicon scheme, used only when SARS-CoV-2 is the specimen organism.
-        ont_read_suffix (str): The read file ending for ONT fastq files.
-        illumina_read1_suffix (str): The read file ending for Illumina read 1 files.
-        illumina_read2_suffix (str): The read file ending for Illumina read 2 files.
-        max_batch_size (int): The maximum number of samples per batch.
+    Use max_batch_size to split into multiple separate upload csvs.
+
+    Adjust the read_suffix parameters to match the file endings for your read files.
     """  # noqa: D205
     if len(country) != 3:
         raise ValueError(f"Country ({country}) should be 3 letter code")
@@ -530,11 +464,7 @@ def build_csv(
 @main.command()
 @click.option("--host", type=str, default=None, help="API hostname (for development)")
 def get_amplicon_schemes(*, host: str | None = None) -> None:
-    """Get valid amplicon schemes from the server.
-
-    Args:
-        host (str | None): The host server (for development).
-    """
+    """Get valid amplicon schemes from the server."""
     schemes = lib.get_amplicon_schemes(host=host)
     logging.info("Valid amplicon schemes:")
     for scheme in schemes:

--- a/upload.csv
+++ b/upload.csv
@@ -1,0 +1,2 @@
+batch_name,sample_name,reads_1,reads_2,control,collection_date,country,subdivision,district,specimen_organism,host_organism,instrument_platform
+mybatch123,sample,/Users/kgoktas/Downloads/samples/sample_1.fastq.gz,/Users/kgoktas/Downloads/samples/sample_2.fastq.gz,,2025-05-27,GBR,,,mycobacteria,homo sapiens,illumina


### PR DESCRIPTION
- i am not sure about the <a> links but current in-document navigation links are not working.
- added link to assets folder of github page
- updated generate_pypi_readme to use actual cli help outputs while generating pypi readme
- updated versions to 2.1.1

https://eit-oxford.atlassian.net/browse/EV-2081